### PR TITLE
fix: bump Node to 22 and pin firebase-tools to 15.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 COPY . /app
 
 RUN apk update \
     && apk add bash git g++ make python3 \
-    && yarn global add firebase-tools
+    && yarn global add firebase-tools@15.17.0
 
 RUN chmod +x /app/entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Bump base image `node:20-alpine` → `node:22-alpine`
- Pin `firebase-tools` to `15.17.0` (was unpinned)

## Why this broke

The unpinned `yarn global add firebase-tools` resolves the latest `firebase-tools` at image build time. The current latest transitively depends on `universal-analytics@0.5.4`, whose `engines` field requires Node `>=22`. The image was on `node:20-alpine`, so yarn refused to install:

```
error universal-analytics@0.5.4: The engine "node" is incompatible with this module.
       Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
ERROR: process "/bin/sh -c apk update ... && yarn global add firebase-tools" did not complete successfully: exit code: 1
```

Every CI job consuming `babbel/firebase-app-distribution.android@v1.0.0` started failing as a result — including `core.ios`'s daily QA build (`daily-qa-build.yml`) and PR QA (`qa-build.yml`).

## Why pinning, not just a Node bump

This is the **third time** Node has been bumped in this Dockerfile for the same root cause (`14 → 20` for firebase-tools 14.0.0; now `20 → 22` for the latest's transitive deps). Each time, the failure surfaces in downstream consumers with no commit in this repo. Pinning `firebase-tools` turns silent transitive-drift breakage into a deliberate, reviewable PR here. firebase-tools' own `engines` is permissive (`>=20`) — the constraint lives in transitive deps, so we can't rely on the top-level version's stated requirements.

## Follow-up

- Cut `v1.0.1` after merge so consumers can bump (`babbel/firebase-app-distribution.android@v1.0.0` → `@v1.0.1`).

## Test plan

- [ ] CI rebuilds the action image successfully
- [ ] Once tagged, a consumer workflow (`core.ios` QA build) uploads an artifact end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)