### PR TITLE
Pin node:22-alpine to last-known-good digest (Node 22.23.0 broke Fire…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-alpine
+# Pin node:22-alpine by digest. The mutable tag rolled to Node 22.23.0 on 2026-06-18
+# (June security release: undici/http.Agent/TLS changes) which broke firebase-tools auth.
+# Last-known-good image, used by passing daily builds on 2026-06-17.
+FROM node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
## Why
The daily Firebase App Distribution upload started failing on 2026-06-18 with `Error: Failed to authenticate, have you run firebase login?`. The APK builds fine; only the Firebase upload step fails.

Root cause: this action builds its image from the mutable `node:22-alpine` tag on every run. On 2026-06-18 that tag rolled to Node 22.23.0 (June security release: undici 6.27.0 + http.Agent/TLS changes), which broke firebase-tools / google-auth-library Workload Identity auth inside the container.

**Evidence** — identical workflow and action `@v1.0.1`, but a different base-image digest between the last passing and first failing daily build:
- Jun 17 (PASS): `node:22-alpine@sha256:e58326...935ffdd`
- Jun 18/19 (FAIL): `node:22-alpine@sha256:ab07539...949d41cd`

## What
Pin `FROM node:22-alpine` to the last-known-good digest `sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd` (Node 22.22.x). No other changes.

## Rollout plan
1. Merge, then tag `v1.0.2-beta`.
2. Canary on `universal-lesson-experience.monorepo` (point its workflow at `@v1.0.2-beta`).
3. If green, promote and roll out to the other consuming repos (incl. `core.android`).

## Follow-ups
- Add Renovate/Dependabot to manage the pinned digest so security patches still flow (gated by CI).
- Track Node 22.23.1 / a google-auth-library fix, then move the pin forward.

Ref: Node.js June 18 2026 security release (CVE-2026-48931 `http.Agent`, CVE-2026-48934 TLS session reuse).